### PR TITLE
Add links to Articles, UX/UI and Podcast

### DIFF
--- a/Issues/Week70.md
+++ b/Issues/Week70.md
@@ -8,6 +8,7 @@
 * [Stupid Disambiguation Tricks](http://www.figure.ink/blog/2015/3/8/stupid-disambiguation-tricks), by [@jemmons](https://twitter.com/jemmons)
 * [An (Almost) TDD Workflow in Swift](http://www.andrewcbancroft.com/2015/03/10/an-almost-tdd-workflow-in-swift/), by [@andrewcbancroft](https://twitter.com/andrewcbancroft)
 * [Building  Watch Apps](http://amro.co/building-apple-watch-apps), by [@amdev](https://twitter.com/amdev)
+* [JSON in Swift](http://blog.scottlogic.com/2015/03/09/json-in-swift.html), by [@iwantmyrealname](https://twitter.com/iwantmyrealname)
 
 **Controls/Tools**
 
@@ -27,11 +28,16 @@
 * [Design Explosions: PBS Kids](https://medium.com/design-explosion/design-explosions-issue-2-pbs-kids-6cb99df3dbd8), by [@uxlaunchpad](https://twitter.com/uxlaunchpad)
 * [5 Reasons You Need to Watch Real People Use Your App](https://teamgaslight.com/blog/5-reasons-you-need-to-watch-real-people-use-your-app), by [@michelletaute](https://twitter.com/michelletaute)
 * [What if Testing Was a Part of the Design](http://blog.froont.com/what-if-testing-was-a-part-of-the-design/), by [@ruluks](https://twitter.com/ruluks)
+* [iOS Video Backgrounds](https://medium.com/@kschaller/ios-video-backgrounds-6eead788f190), by [@kschaller](https://twitter.com/kschaller)
 
 
 **Videos**
 
 * [Mike Monteiro - How to Sell Your Work](https://vimeo.com/121082134), by [@monteiro](https://twitter.com/monteiro)
+
+**Podcast**
+
+* [Bonus Episode 1: Apple Watch Watch 2015 (feat. Sam Soffes)](http://www.designdetails.fm/bonus-episode-1/), hosted by [@uberbryn] (https://twitter.com/uberbryn) and [@brian_lovin](https://twitter.com/brian_lovin) featuring [@soffes](https://twitter.com/soffes)
 
 **Goodies**
 


### PR DESCRIPTION
Articles - JSON in Swift
Note: Changed the title that appears on blog post: SWIFT JSON SHOOT-OUT

UX/UI - iOS Video Backgrounds
Note: I have a few doubts where this link should be or if it should be at all. Although the article explains how to do it, it's about this new trend (?), so I thought it could be in interesting to include.
Whatever you decide is perfect.

Podcast - Bonus Episode 1: Apple Watch Watch 2015