### PR TITLE
Added the open source route planner GraphHopper under tools for Week77.md

### DIFF
--- a/Issues/Week77.md
+++ b/Issues/Week77.md
@@ -9,6 +9,7 @@
 
 
 **Tools/Controls**
+* [The open source route planner GraphHopper is available for iOS](https://github.com/graphhopper/graphhopper-ios), by [@clns](https://twitter.com/calinseciu)
 
 
 **Business**


### PR DESCRIPTION
I'm the author of GraphHopper and @clns wrote an iOS port which allows offline and fast route calculations