### PR TITLE
Added SCXcodeEditorInset and SCXcodeTabSwitcher

### DIFF
--- a/Issues/Week82.md
+++ b/Issues/Week82.md
@@ -6,6 +6,9 @@
 
 **Tools/Controls**
 
+* [SCXcodeEditorInset](https://github.com/stefanceriu/SCXcodeEditorInset), by [@stefanceriu](https://twitter.com/stefanceriu)
+* [SCXcodeTabSwitcher](https://github.com/stefanceriu/SCXcodeTabSwitcher), by [@stefanceriu](https://twitter.com/stefanceriu)
+
 **Business**
 
 * [How I almost killed my most successful app](https://medium.com/@kirualex/how-i-almost-killed-my-most-successful-app-9dbbd5a2144c), by [@alexiscreuzot](https://twitter.com/alexiscreuzot)


### PR DESCRIPTION
Here's two brand new Xcode plugins for you :wink: 

SCXcodeEditorInset lets you add an empty (configurable) space to the end of Xcode's editor text view (à la AppCode) and SCXcodeTabSwitcher enables changing Xcode tabs using the ⌘cmd + [1..9] keys.