### PR TITLE
Add SwiftAlgorithmsClassroom

### DIFF
--- a/Issues/Week106.md
+++ b/Issues/Week106.md
@@ -12,6 +12,8 @@
 **Tools/Controls**
 
 * [Compass](https://github.com/hyperoslo/Compass), by [@hyperoslo](https://twitter.com/hyperoslo) 
+* [SwiftAlgorithmsClassroom](https://github.com/gmertk/SwiftAlgorithmsClassroom), by [@gunaymertk](https://twitter.com/gunaymertk)
+
 
 
 **Business**
@@ -32,10 +34,6 @@
 
 *
 
-**Course**
-
-* [Swift Algorithms Classroom](https://github.com/gmertk/SwiftAlgorithmsClassroom)
-
 **Credits**
 
-* [rbarbosa](https://github.com/rbarbosa), [mariusc](https://github.com/mariusc), [ricardopereiraw](https://github.com/ricardopereiraw), [zenangst](https://github.com/zenangst), [Ben-G](https://github.com/Ben-G)
+* [rbarbosa](https://github.com/rbarbosa), [mariusc](https://github.com/mariusc), [ricardopereiraw](https://github.com/ricardopereiraw), [zenangst](https://github.com/zenangst), [Ben-G](https://github.com/Ben-G), [gmertk](https://github.com/gmertk)

--- a/Issues/Week106.md
+++ b/Issues/Week106.md
@@ -32,6 +32,9 @@
 
 *
 
+**Course**
+
+* [Swift Algorithms Classroom](https://github.com/gmertk/SwiftAlgorithmsClassroom)
 
 **Credits**
 


### PR DESCRIPTION
Hi, I am just starting a github based classroom for algorithms with Swift. https://github.com/gmertk/SwiftAlgorithmsClassroom

Not sure if I should create a **Course** category, but couldn't fit it in the other categories.