### PR TITLE
Add 'Moving to WatchOS 2'

### DIFF
--- a/Issues/Week107.md
+++ b/Issues/Week107.md
@@ -3,6 +3,7 @@
 * [How to Handle Errors When You're Not Interested in the Details](http://christiantietze.de/posts/2015/11/error-handling-attempt/), by [@ctietze](https://twitter.com/ctietze)
 * [Asynchronicity and the Main Thread: Part 2](http://www.figure.ink/blog/2015/11/22/asynchrony-and-the-main-thread-part-2), by [@jemmons](https://twitter.com/jemmons)
 * [Swift Sequences](https://medium.com/swift-programming/swift-sequences-ce22d76f120c#.il08ci7nx), by [@greg3z](https://twitter.com/greg3z)
+* [Moving to WatchOS 2](http://fancypixel.github.io/blog/2015/11/24/moving-to-watchos-2/), by [@theandreamazz](https://twitter.com/theandreamazz)  
 
 **Tools/Controls**
 


### PR DESCRIPTION
Added [this blog post](http://fancypixel.github.io/blog/2015/11/24/moving-to-watchos-2/) about porting a WatchOS 1 app to WatchOS 2, covering data sharing and complications. 

Cheers 
