### PR TITLE
Add TextAttributes

### DIFF
--- a/Issues/Week126.md
+++ b/Issues/Week126.md
@@ -16,6 +16,7 @@
 
 * [Caishen](https://github.com/prolificinteractive/Caishen), by [@weareprolific](https://twitter.com/weareprolific)
 * [SkyFloatingLabelTextField](https://github.com/Skyscanner/SkyFloatingLabelTextField), by [@rumori](https://twitter.com/rumori), [@GergelyOrosz](https://twitter.com/GergelyOrosz) & [@wolffan](https://twitter.com/wolffan)
+* [TextAttributes](https://github.com/delba/TextAttributes), by [@delba](https://github.com/delba)
 
 **Business**
 
@@ -35,4 +36,4 @@
 
 **Credits**
 
-* [mluisbrown](https://github.com/mluisbrown), [prolificinteractive](https://github.com/prolificiinteractive), [rbarbosa](https://github.com/rbarbosa), [mariusc](https://github.com/mariusc), [lucianomarisi](https://github.com/lucianomarisi), [GergelyOrosz](https://github.com/gergelyorosz)
+* [mluisbrown](https://github.com/mluisbrown), [prolificinteractive](https://github.com/prolificiinteractive), [rbarbosa](https://github.com/rbarbosa), [mariusc](https://github.com/mariusc), [lucianomarisi](https://github.com/lucianomarisi), [GergelyOrosz](https://github.com/gergelyorosz), [delba](https://github.com/delba)


### PR DESCRIPTION
Attributed strings are everywhere and dealing with loosely typed / autocompletion unfriendly `[String: AnyObject]` dictionaries is a pain.

**TextAttributes** makes it easy to compose attributed strings.

```swift
let attrs = TextAttributes()
    .font(name: "HelveticaNeue", size: 16)
    .foregroundColor(white: 0.2, alpha: 1)
    .lineHeightMultiple(1.5)

NSAttributedString("The quick brown fox jumps over the lazy dog", attributes: attrs)
```

Please see the [README](https://github.com/delba/TextAttributes) or the source code (fully documented) for more info.