### PR TITLE
Add TextAttributes

### DIFF
--- a/Issues/Week127.md
+++ b/Issues/Week127.md
@@ -7,6 +7,7 @@
 **Tools/Controls**
 
 * [PresenterKit](https://github.com/jessesquires/PresenterKit), by [@jesse_squires](https://twitter.com/jesse_squires)
+* [TextAttributes](https://github.com/delba/TextAttributes), by [@delba](https://github.com/delba)
 
 **Business**
 
@@ -22,4 +23,4 @@
 
 **Credits**
 
-* [rbarbosa](https://github.com/rbarbosa), [lkmfz](https://github.com/lkmfz)
+* [rbarbosa](https://github.com/rbarbosa), [lkmfz](https://github.com/lkmfz), [delba](https://github.com/delba)


### PR DESCRIPTION
Attributed strings are everywhere and dealing with loosely typed / autocompletion unfriendly `[String: AnyObject]` dictionaries is a pain.

**TextAttributes** makes it easy to compose attributed strings.

```swift
let attrs = TextAttributes()
    .font(name: "HelveticaNeue", size: 16)
    .foregroundColor(white: 0.2, alpha: 1)
    .lineHeightMultiple(1.5)

NSAttributedString("The quick brown fox jumps over the lazy dog", attributes: attrs)
```

Please see the [README](https://github.com/delba/TextAttributes) or the source code (fully documented) for more info.