### PR TITLE
Added CocoaPods 1.0

### DIFF
--- a/Issues/Week131.md
+++ b/Issues/Week131.md
@@ -1,3 +1,4 @@
+* [CocoaPods 1.0](http://blog.cocoapods.org/CocoaPods-1.0/)
 
 **Articles**
 


### PR DESCRIPTION
I think the 1.0 CocoaPods release deserves a spot in our newsletter. I'm not really sure where it should be. Personally, I think top of the issue, under no category is best, because it's a major achievement on which the team has been working for around 4 years, and in the meantime, helped build the iOS community.

Let me know if you think it should be under a different category