### PR TITLE
Propose Networking for the Tools section

### DIFF
--- a/Issues/Week132.md
+++ b/Issues/Week132.md
@@ -8,7 +8,7 @@
 
 * [PMAlertController](https://github.com/Codeido/PMAlertController), by [@pmusolino](https://twitter.com/pmusolino)
 * [Render](https://github.com/alexdrone/Render), by [@alexdrone](https://github.com/alexdrone)
-* 
+* [Networking](https://github.com/3lvis/Networking), by [@3lvis](https://twitter.com/3lvis)
 
 **Business**
 
@@ -24,4 +24,4 @@
 
 **Credits**
 
-* [Codeido](https://github.com/Codeido), [mariusc](https://github.com/mariusc), [uraimo](https://github.com/uraimo)
+* [Codeido](https://github.com/Codeido), [mariusc](https://github.com/mariusc), [uraimo](https://github.com/uraimo), [3lvis](https://github.com/3lvis)


### PR DESCRIPTION
Networking is just a plain, simple and convenient wrapper around NSURLSession that supports common needs such as faking requests and caching images out of the box.

This week has finally reached 1.0.0!