### PR TITLE
Add XcodeColorSense

### DIFF
--- a/Issues/Week132.md
+++ b/Issues/Week132.md
@@ -13,6 +13,7 @@
 * [Networking](https://github.com/3lvis/Networking), by [@3lvis](https://twitter.com/3lvis)
 * [GSKStretchyHeaderView](https://github.com/gskbyte/GSKStretchyHeaderView), by [@gskbyte](https://twitter.com/gskbyte)
 * [MEVHorizontalContacts](https://github.com/manuelescrig/MEVHorizontalContacts), by [@manuelescrig](https://twitter.com/manuelescrig)
+* [XcodeColorSense](https://github.com/onmyway133/XcodeColorSense), by [@onmyway133](https://twitter.com/onmyway133)
 
 **Business**
 
@@ -29,4 +30,4 @@
 
 **Credits**
 
-* [Codeido](https://github.com/Codeido), [mariusc](https://github.com/mariusc), [uraimo](https://github.com/uraimo), [3lvis](https://github.com/3lvis), [rbarbosa](https://github.com/rbarbosa), [gskbyte](https://github.com/gskbyte), [manuelescrig](https://github.com/manuelescrig), [lkmfz](https://github.com/lkmfz)
+* [Codeido](https://github.com/Codeido), [mariusc](https://github.com/mariusc), [uraimo](https://github.com/uraimo), [3lvis](https://github.com/3lvis), [rbarbosa](https://github.com/rbarbosa), [gskbyte](https://github.com/gskbyte), [manuelescrig](https://github.com/manuelescrig), [lkmfz](https://github.com/lkmfz), [onmyway133](https://github.com/onmyway133)


### PR DESCRIPTION
Hi, since I constantly use hex color in my apps, and find myself switching between Xcode and http://www.hexcolortool.com/. 😢 

I thought an Xcode plugins could help this much. So [XcodeColorSense](https://github.com/onmyway133/XcodeColorSense) was born 🎉 

Hope it helps other people, too. It is easily extensible, through `Matcher` protocol. For now there is matchers for Hex, RGBA, preset colors.

![](https://github.com/onmyway133/XcodeColorSense/raw/master/Screenshots/XcodeColorSense.png)