### PR TITLE
Add SwiftyOAuth

### DIFF
--- a/Issues/Week134.md
+++ b/Issues/Week134.md
@@ -7,7 +7,7 @@
 **Tools/Controls**
 
 * [Alembic](https://github.com/ra1028/Alembic), by ra1028
-*
+* [SwiftyOAuth](https://github.com/delba/SwiftyOAuth), by [delba](https://github.com/delba)
 
 **Business**
 
@@ -23,4 +23,4 @@
 
 **Credits**
 
-* [ra1028](https://github.com/ra1028)
+* [ra1028](https://github.com/ra1028), [delba](https://github.com/delba)


### PR DESCRIPTION
**SwiftyOAuth** is a *small* OAuth2 library with a built-in set of [providers](https://github.com/delba/SwiftyOAuth#providers). It supports both the server-side (explicit) and the client-side (implicit) flows.

In its simplest form, it looks like this:

```swift
let instagram: Provider = .Instagram(clientID: "***", redirectURL: "foo://callback")

instagram.authorize { result in
    print(result) // Success(Token(accessToken: "abc123"))
}
```

The [wiki](https://github.com/delba/SwiftyOAuth/wiki) includes detailed information on each of the built-in providers.

A previous PR for SwiftyOAuth was [merged](https://github.com/iOS-Goodies/iOS-Goodies/commit/3e394f6d0310ce66897cb26e3bab5ae9c260c281) but didn't make it in the [newsletter](http://ios-goodies.com/post/144263230356/week-131). Is it possible for it to be included in next week iOS goodies ?

Thanks!
