### PR TITLE
Add "Exploring Hidden Constraints in the Public Interface of UITabBar" article

### DIFF
--- a/Issues/Week135.md
+++ b/Issues/Week135.md
@@ -11,6 +11,7 @@
 * [Limiting concurrent execution using GCD](http://dx13.co.uk/articles/2016/6/4/limiting-concurrent-execution-using-gcd.html), by [@mikerhodes](https://twitter.com/mikerhodes)
 * [How iOS Apps on the Mac Could Work](https://medium.com/@sandofsky/how-ios-apps-on-the-mac-could-work-13aa32a2647b), by [@sandofsky](https://twitter.com/sandofsky)
 * [Configuration In Swift](http://khanlou.com/2016/06/configuration-in-swift/), by [@khanlou](https://twitter.com/khanlou)
+* [Exploring Hidden Constraints in the Public Interface of UITabBar](http://www.augustyniak.me/post/Exploring-Hidden-Constraints-in-the-Public-Interface-of-UITabBar/), by [@RaAugustyniak](https://twitter.com/RaAugustyniak)
 
 
 **Tools/Controls**
@@ -36,4 +37,4 @@
 
 **Credits**
 
-* [rbarbosa](https://github.com/rbarbosa), [tomkowz](https://github.com/tomkowz), [lkmfz](https://github.com/lkmfz), [onmyway133](https://github.com/onmyway133), [rahulkatariya](https://github.com/rahulkatariya), [mariusc](https://github.com/mariusc)
+* [rbarbosa](https://github.com/rbarbosa), [tomkowz](https://github.com/tomkowz), [lkmfz](https://github.com/lkmfz), [onmyway133](https://github.com/onmyway133), [rahulkatariya](https://github.com/rahulkatariya), [mariusc](https://github.com/mariusc), [RaAugustyniak](https://twitter.com/RaAugustyniak)


### PR DESCRIPTION
My article focuses on the note from the Apple's documentation of `UITabBar` class. It turns out that instance of `UITabBar`, which is managed by `UITabBarController`, can't be modified. Documentation states that attempt to modify that kind of tab bar leads to crash.

That's interesting - we have situation in which public interface of tab bar/tab bar controller is in contrary to the documentation notes. Compiler allows us to modify tab bar but mentioned notes explicitly state that is forbidden.

In my article:
1. I investigate the way tab bar is protected from modifications
2. I look for similar interfaces within Cocoa framework
3. I express my opinion about that kind of interfaces.
4. I present alternative solution (using Swift) for public interfaces of tab bar controller and tab bar classes.  New interfaces enforce constraints presented in Apple’s documentation and don't allow their users to perform forbidden actions. 

Thanks for a great work!