### PR TITLE
Fix 'XCode' with 'Xcode'

### DIFF
--- a/Issues/Week143.md
+++ b/Issues/Week143.md
@@ -5,7 +5,7 @@
 * [Enums as configuration: the anti-pattern](http://www.jessesquires.com/enums-as-configs/), by [@jesse_squires](https://twitter.com/jesse_squires)
 * [Exposing view model properties in ReactiveCocoa](http://www.martinrichter.net/blog/2016/07/30/exposing-view-model-properties-in-rac/), by [@richeterre](https://twitter.com/richeterre)
 * [Looking Back on Swift 3 and Ahead to Swift 4](http://mjtsai.com/blog/2016/07/30/looking-back-on-swift-3-and-ahead-to-swift-4/), by [@mjtsai](https://twitter.com/mjtsai)
-* [XCode 8: New Build Settings and Analyzer Improvements](http://www.miqu.me/blog/2016/07/31/xcode-8-new-build-settings-and-analyzer-improvements/), by [@miguelquinon](https://twitter.com/miguelquinon)
+* [Xcode 8: New Build Settings and Analyzer Improvements](http://www.miqu.me/blog/2016/07/31/xcode-8-new-build-settings-and-analyzer-improvements/), by [@miguelquinon](https://twitter.com/miguelquinon)
 
 **Tools/Controls**
 


### PR DESCRIPTION
Just realized I did the inverse of what @rbarbosa mentioned in the title here. Honestly never paid attention to the difference between XCode and Xcode 😳.

BTW fixed in article as well. Thanks for feedback and sorry for double pull requests!