### PR TITLE
Added Magic Sudoku posts

### DIFF
--- a/Issues/Week200.md
+++ b/Issues/Week200.md
@@ -10,6 +10,8 @@
 
 * [Why Trello Failed to Build a $1 Billion+ Business](https://blog.usejournal.com/why-trello-failed-to-build-a-1-billion-business-e1579511d5dc), by [@hnshah](https://twitter.com/hnshah)
 * [No, Trello Didn’t “Fail To Build A Billion Dollar Business”](https://medium.com/hi-my-name-is-jon/no-trello-didnt-fail-to-build-a-billion-dollar-business-25264b08b0cb), by [@jonwestenberg](https://twitter.com/jonwestenberg)
+* [Why we built Magic Sudoku, the ARKit Sudoku Solver - Part 1](https://blog.prototypr.io/why-we-built-magic-sudoku-the-arkit-sudoku-solver-306dde6c0a77), by [Brad Dwyer](https://www.twitter.com/braddwyer)
+* [Behind the Magic: How we built the ARKit Sudoku Solver - Part 2](https://blog.prototypr.io/behind-the-magic-how-we-built-the-arkit-sudoku-solver-e586e5b685b0), by [Brad Dwyer](https://www.twitter.com/braddwyer)
 
 **UI/UX**
 
@@ -21,4 +23,4 @@
 
 **Credits**
 
-* [LisaDziuba](https://github.com/LisaDziuba), [rbarbosa](https://github.com/rbarbosa)
+* [LisaDziuba](https://github.com/LisaDziuba), [rbarbosa](https://github.com/rbarbosa), [FranciscoAmado](https://github.com/FranciscoAmado)


### PR DESCRIPTION
Hi! 
This posts are from a 3-part series from the creator [Brad Dwyer](https://www.twitter.com/braddwyer).
I thought suggesting the 2nd (recently posted) without the 1st wouldn't make much sense.
Also, although the articles were created because of the app, should they be put in the business section since they approach other aspects of the product?

Finally, I realise **iOS Goodies** isn't for endorsing apps but this one is pretty interesting and would be cool to suggest the readers to try it out?   https://magicsudoku.com/download

Cheers 🍪