### PR TITLE
Adds iOS 11 API Diffs: UIViewController.h Article

### DIFF
--- a/Issues/Week200.md
+++ b/Issues/Week200.md
@@ -31,4 +31,4 @@
 
 **Credits**
 
-* [LisaDziuba](https://github.com/LisaDziuba), [rbarbosa](https://github.com/rbarbosa), [EnnioMa](https://github.com/ennioma), [FranciscoAmado](https://github.com/FranciscoAmado), [AnderGoig](https://github.com/AnderGoig), [AlbertoMoral](https://github.com/MoralAlberto)
+* [LisaDziuba](https://github.com/LisaDziuba), [rbarbosa](https://github.com/rbarbosa), [EnnioMa](https://github.com/ennioma), [FranciscoAmado](https://github.com/FranciscoAmado), [AnderGoig](https://github.com/AnderGoig), [AlbertoMoral](https://github.com/MoralAlberto), [phillfarrugia](https://github.com/phillfarrugia)

--- a/Issues/Week200.md
+++ b/Issues/Week200.md
@@ -4,6 +4,7 @@
 * [Snapshot Testing in Swift](http://www.stephencelis.com/2017/09/snapshot-testing-in-swift), by [Stephen Celis](https://twitter.com/stephencelis)
 * [Back to the fundamentals: Sorting algorithms in Swift (from scratch!)](https://medium.com/@EnnioMa/back-to-the-fundamentals-sorting-algorithms-in-swift-from-scratch-fccf8a3daea3)
 * [RAS S1E4](http://codeplease.io/2017/10/16/ras-s1e4/), by [@peres](https://twitter.com/peres)
+* [iOS 11 API Diffs: UIViewController.h](https://medium.com/@phillfarrugia/ios-11-0-api-diffs-uiviewcontroller-h-158883a38507), by [@phillfarrugia](https://twitter.com/phillfarrugia)
 
 **Tools/Controls**
 


### PR DESCRIPTION
I wrote an article about iOS 11, where I dive into the diffs of UIViewController.h. It was a useful way for me to dive into the new Safe Area changes a bit, I hope that the community might also benefit/save time.