### PR TITLE
Add XcodeWay

### DIFF
--- a/Issues/Week200.md
+++ b/Issues/Week200.md
@@ -15,6 +15,7 @@
 * [Send It - Safari Extension for Slack](https://github.com/MoralAlberto/Send-It-for-Slack), by [Alberto Moral](https://twitter.com/albertmoral)
 * [Cards](https://github.com/PaoloCuscela/Cards), by [PaoloCuscela](https://github.com/PaoloCuscela)
 * [DrawerKit](https://github.com/Babylonpartners/DrawerKit), by [Babylonpartners](https://github.com/Babylonpartners)
+* [XcodeWay](https://github.com/onmyway133/XcodeWay), by [onmyway133](https://github.com/onmyway133/)
 
 **Business**
 
@@ -36,4 +37,4 @@
 
 **Credits**
 
-* [LisaDziuba](https://github.com/LisaDziuba), [rbarbosa](https://github.com/rbarbosa), [EnnioMa](https://github.com/ennioma), [FranciscoAmado](https://github.com/FranciscoAmado), [AnderGoig](https://github.com/AnderGoig), [AlbertoMoral](https://github.com/MoralAlberto), [phillfarrugia](https://github.com/phillfarrugia)
+* [LisaDziuba](https://github.com/LisaDziuba), [rbarbosa](https://github.com/rbarbosa), [EnnioMa](https://github.com/ennioma), [FranciscoAmado](https://github.com/FranciscoAmado), [AnderGoig](https://github.com/AnderGoig), [AlbertoMoral](https://github.com/MoralAlberto), [phillfarrugia](https://github.com/phillfarrugia), [onmyway133](https://github.com/onmyway133)


### PR DESCRIPTION
Hi, first of all, congrats on iOS Goodies reaching issue 200. I like this a lot, and it is the only newsletter that I read.

Here is https://github.com/onmyway133/XcodeWay, an Xcode Source Editor Extension that help navigating to many places easier. It was my first open source project as an Xcode plugin before Xcode 8. I then refactor it to Xcode extension. Now it is Xcode extension with Apple Script, so the possibility to extend is endless.

![](https://github.com/onmyway133/XcodeWay/raw/master/Screenshots/demo.gif)