### PR TITLE
Add article 'Spectre and Meltdown fixes influence on iOS apps build time'

### DIFF
--- a/Issues/Week216.md
+++ b/Issues/Week216.md
@@ -2,6 +2,7 @@
 
 * [Dependency Management for iOS projects with the Swift package manager](http://www.ralfebert.de/ios-examples/xcode/ios-dependency-management-with-swift-package-manager/), by [@ralfebert](https://twitter.com/ralfebert)
 * [Parents and children problems 😅](https://ruiper.es/2018/02/06/parents-children-problems/), by [@peres](https://twitter.com/peres)
+* [Spectre and Meltdown fixes influence on iOS apps build time](https://medium.com/@rdovhaliuk/spectre-and-meltdown-fixes-influence-on-ios-apps-build-time-40b3f7b4bca6), by Rostyslav Dovhaliuk
 
 **Tools/Controls**
 
@@ -21,4 +22,4 @@
 
 **Credits**
 
-* [ralfebert](https://github.com/ralfebert), [rbarbosa](https://github.com/rbarbosa)
+* [ralfebert](https://github.com/ralfebert), [rbarbosa](https://github.com/rbarbosa), [RenGate](https://github.com/RenGate)


### PR DESCRIPTION
Hello folks. There was quite a lot of buzz around Spectre/Meltdown vulnerabilities during last month. I've decided to run a small benchmark to check how recent fixes will affect iOS apps compilation speed. Hope you'll like it. Thanks!