### PR TITLE
Adding ReactiveLists Tool and Article

### DIFF
--- a/Issues/Week216.md
+++ b/Issues/Week216.md
@@ -3,10 +3,12 @@
 * [Dependency Management for iOS projects with the Swift package manager](http://www.ralfebert.de/ios-examples/xcode/ios-dependency-management-with-swift-package-manager/), by [@ralfebert](https://twitter.com/ralfebert)
 * [Parents and children problems 😅](https://ruiper.es/2018/02/06/parents-children-problems/), by [@peres](https://twitter.com/peres)
 * [Spectre and Meltdown fixes influence on iOS apps build time](https://medium.com/@rdovhaliuk/spectre-and-meltdown-fixes-influence-on-ios-apps-build-time-40b3f7b4bca6), by Rostyslav Dovhaliuk
+* [Open Sourcing ReactiveLists for iOS](https://medium.com/plangrid-technology/open-sourcing-reactivelists-for-ios-3abdf41b770a), by [@benjaminencz](https://twitter.com/benjaminencz)
 
 **Tools/Controls**
 
 * [CapsuleView](https://github.com/umarF/capsuleview), by [@umarF](https://github.com/umarF)
+* [ReactiveLists - React-like API for UITableView & UICollectionView](https://github.com/plangrid/ReactiveLists), by [@PlanGrid](https://twitter.com/PlanGrid)
 
 **Business**
 
@@ -22,4 +24,4 @@
 
 **Credits**
 
-* [ralfebert](https://github.com/ralfebert), [rbarbosa](https://github.com/rbarbosa), [RenGate](https://github.com/RenGate)
+* [ralfebert](https://github.com/ralfebert), [rbarbosa](https://github.com/rbarbosa), [RenGate](https://github.com/RenGate), [FranciscoAmado](https://github.com/FranciscoAmado)


### PR DESCRIPTION
Hey there!

@plangrid Open-sourced its [ReactiveLists](https://github.com/plangrid/ReactiveLists) component. Pretty interesting 👍🏻

I've also added the article wrote by @Ben-G about open-sourcing it because it also provides their view on how open-sourcing helps achieving a better app architecture.

Cheers 🍪