### PR TITLE
Adding Smart Sizing Grid Article

### DIFF
--- a/Issues/Week238.md
+++ b/Issues/Week238.md
@@ -1,6 +1,7 @@
 **Articles**
 
 * [UIWindow, rootViewController, visual artifacts and leaks.](https://medium.com/appssemble/uiwindow-rootviewcontroller-visual-artifacts-and-leaks-6b6676f92a49), by [@dobreandl](https://twitter.com/dobreandl)
+* [Smart Grid Sizing](https://pspdfkit.com/blog/2018/smart-grid-sizing/), by [@qdoug](https://twitter.com/qdoug) for [@PSPDFKit](https://twitter.com/PSPDFKit)
 
 **Tools/Controls**
 
@@ -20,4 +21,4 @@
 
 **Credits**
 
-* [dobreandl](https://github.com/dobreandl)
+* [dobreandl](https://github.com/dobreandl), [FranciscoAmado](https://github.com/FranciscoAmado)


### PR DESCRIPTION
Hi there!

Adding the "Smart Sizing Grid" that PSPDFKit uses for dynamically calculating the item size in their thumbnail collections. Pretty cool 👍🏻

## Checklist

* [x] The links are in the correct format
* [x] I added my self to the credits with my GitHub account

## Optional

* [x] Article is not more than 2 weeks old
* [x] Article wasn't submitted before 

