### PR TITLE
Added CSProgress Tool

### DIFF
--- a/Issues/Week250.md
+++ b/Issues/Week250.md
@@ -12,6 +12,7 @@
 * [AlignedCollectionViewFlowLayout](https://github.com/mischa-hildebrand/AlignedCollectionViewFlowLayout), by [@mischa-hildebrand](https://github.com/mischa-hildebrand)
 * [Sizes - View your app on different device and font sizes](https://github.com/marcosgriselli/Sizes), by [@marcosgriselli](https://twitter.com/marcosgriselli)
 * [PermissionsKit - convenience wrapper on macOS permissions API](https://github.com/MacPaw/PermissionsKit), by Serg Krivoblotsky
+* [CSProgress - A higher-performing, easier-to-use replacement class for Apple's NSProgress](https://github.com/CharlesJS/CSProgress), by CharlesJS
 
 
 **Business/Career**


### PR DESCRIPTION
Hi there!

@CharlesJS Built a replacement for `NSProgress`. At first glance it looks cool and it is written in Swift 👍🏻

Cheers 🍪

## Checklist

* [x] The links are in the correct format: ``[Title of the Article](link), by [@author/`s Twitter username](link-for-twitter)`` **-- No Twitter link**
* [x] I added my self to the credits with my GitHub account: ``[GitHub account](link-to-github]`` -- **Already in the credits**


