### PR TITLE
Move article from week 260 to week 262

### DIFF
--- a/Issues/Week260.md
+++ b/Issues/Week260.md
@@ -2,7 +2,6 @@ Happy Thursday! One article that was shared quite a lot this week is "[Flutter w
 
 **Articles**
 
-* [8 Runtime Linters to Help Clean Up Your Code Base](https://medium.com/@michael.eisel/runtime-checking-on-ios-1234b5294998), by [@michaeleisel](https://twitter.com/michaeleisel)
 * [Solving dependencies in Swift](https://medium.com/@JuanpeCatalan/solving-dependencies-in-swift-9ee6ad4a8941), by [@JuanpeCatalan](https://twitter.com/JuanpeCatalan)
 * [How to convert your Xcode plugins to Xcode extensions](https://medium.freecodecamp.org/how-to-convert-your-xcode-plugins-to-xcode-extensions-ac90f32ae0e3), by [@onmyway133](https://twitter.com/onmyway133)
 * [Watermarking photos with ImageMagick, Vapor 3 and Swift on macOS and Linux](https://mikemikina.com/blog/watermarking-photos-with-imagemagick-vapor-3-and-swift-on-macos-and-linux/), by [@MikeMikina](https://twitter.com/mikemikina)
@@ -37,4 +36,4 @@ Happy Thursday! One article that was shared quite a lot this week is "[Flutter w
 
 **Credits**
 
-* [onmyway133](https://github.com/onmyway133), [pmusolino](https://www.github.com/pmusolino), [ott_max](https://github.com/max-ott), [mikina](https://www.github.com/mikina), [michaeleisel](https://github.com/michaeleisel), [LisaDziuba](https://github.com/lisadziuba), [rbarbosa](https://github.com/rbarbosa)
+* [onmyway133](https://github.com/onmyway133), [pmusolino](https://www.github.com/pmusolino), [ott_max](https://github.com/max-ott), [mikina](https://www.github.com/mikina), [LisaDziuba](https://github.com/lisadziuba), [rbarbosa](https://github.com/rbarbosa)

--- a/Issues/Week262.md
+++ b/Issues/Week262.md
@@ -1,7 +1,7 @@
 
 **Articles**
 
-* 
+* [8 Runtime Linters (and how to create your own)](https://medium.com/@michael.eisel/runtime-checking-on-ios-1234b5294998), by [@michaeleisel](https://twitter.com/michaeleisel)
 
 **Tools/Controls**
 
@@ -21,4 +21,4 @@
 
 **Credits**
 
-* [karolkulesza](https://github.com/karolkulesza)
+* [karolkulesza](https://github.com/karolkulesza), [michaeleisel](https://github.com/michaeleisel)


### PR DESCRIPTION
Without realizing it, I added my article to week 260 after it was already released. You can see that it's missing from week 260 at https://ios-goodies.com/ . I'd like to move it to week 262 instead, since that one hasn't been released.

## Checklist

* [X] The links are in the correct format: ``[Title of the Article](link), by [@author/`s Twitter username](link-for-twitter)``
* [X] I added my self to the credits with my GitHub account: ``[GitHub account](link-to-github)``

## Optional

* [X] Article is not more than 2 weeks old (well, it wasn't when I added it to week 260!)
* [ ] Article wasn't submitted before 

