### PR TITLE
Add link to CarLensCollectionViewLayout article

### DIFF
--- a/Issues/Week265.md
+++ b/Issues/Week265.md
@@ -9,7 +9,7 @@
 
 **Tools/Controls**
 
-* [CarLensCollectionViewLayout](https://github.com/netguru/CarLensCollectionViewLayout), by [@netguru](https://twitter.com/netguru)
+* CarLensCollectionViewLayout [repository](https://github.com/netguru/CarLensCollectionViewLayout) and [article](https://www.netguru.com/codestories/introducing-carlenscollectionviewlayout-a-new-open-source-ios-tool-by-netguru), by [@netguru](https://twitter.com/netguru)
 
 **Business/Career**
 


### PR DESCRIPTION
## Checklist

* [x] The links are in the correct format: ``[Title of the Article](link), by [@author/`s Twitter username](link-for-twitter)``
* [x] I added my self to the credits with my GitHub account: ``[GitHub account](link-to-github)``

## Optional

* [x] Article is not more than 2 weeks old
* [x] Article wasn't submitted before 

Hi, I've updated the CarLensCollectionViewLayout tool with an introductory article, which was published just a few minutes ago. Thanks!