### PR TITLE
Add project link for a macOS screen saver based on the opening animation from Apple Event Sep 10, 2019

### DIFF
--- a/Issues/Week300.md
+++ b/Issues/Week300.md
@@ -23,4 +23,4 @@
 
 **Credits**
 
-* [valianka](https://github.com/valianka), [RenGate](https://github.com/rengate), [shipinev](https://github.com/shipinev)
+* [Jimmy Ti](https://github.com/jimmyti), [RenGate](https://github.com/rengate), [shipinev](https://github.com/shipinev), [valianka](https://github.com/valianka)

--- a/Issues/Week300.md
+++ b/Issues/Week300.md
@@ -7,6 +7,7 @@
 **Tools/Controls**
 
 * [ConcentricOnboarding - SwiftUI library for a walkthrough or onboarding flow with tap actions](https://github.com/exyte/ConcentricOnboarding), by [@ExyteHQ](https://twitter.com/exyteHQ)
+* [WonderfulTools - macOS screen saver based on the opening animation from Apple Event, September 2019](https://github.com/jimmyti/WonderfulTools), by [@jimmyti](https://twitter.com/jimmyti)
 
 **Business/Career**
 


### PR DESCRIPTION
## Checklist

* [x] The links are in the correct format: ``[Title of the Article](link), by [@author/`s Twitter username](link-for-twitter)``
* [x] I added my self to the credits with my GitHub account: ``[GitHub account](link-to-github)``

## Optional

* [x] Article is not more than 2 weeks old
* [x] Article wasn't submitted before 

