### PR TITLE
Fixed typo on title and link

### DIFF
--- a/Issues/Week307.md
+++ b/Issues/Week307.md
@@ -2,7 +2,7 @@
 **Articles**
 
 * [CAEmitterBehavior](https://bryce.co/caemitterbehavior/), by [@brycepauken](https://twitter.com/brycepauken)
-* [Show a banner from anywhere in SwiftUI using SwiftModifier](https://www.morningswiftui.com/blog/show-a-banner-from-anywhere-in-swiftui-using-swiftmodifier), by [@thomassivilay](https://twitter.com/thomassivilay)
+* [Show a banner from anywhere in SwiftUI using ViewModifier](https://www.morningswiftui.com/blog/show-a-banner-from-anywhere-in-swiftui-using-viewmodifier), by [@thomassivilay](https://twitter.com/thomassivilay)
 
 **Tools/Controls**
 


### PR DESCRIPTION
Fixing a typo that someone raise to me on Twitter. I meant `ViewModifier` and not `SwiftModifier`. 

## Checklist

* [x] The links are in the correct format: ``[Title of the Article](link), by [@author/`s Twitter username](link-for-twitter)``
* [x] I added my self to the credits with my GitHub account: ``[GitHub account](link-to-github)``

## Optional

* [x] Article is not more than 2 weeks old
* [x] Article wasn't submitted before 

