### PR TITLE
Add article 'Lessons learned from handling JWT on mobile' to Week312.md

### DIFF
--- a/Issues/Week312.md
+++ b/Issues/Week312.md
@@ -1,7 +1,8 @@
 
 **Articles**
 
-* [The Advanced Guide to UserDefaults in Swift](https://www.vadimbulavin.com/advanced-guide-to-userdefaults-in-swift/), by [@V8tr](https://twitter.com/V8tr)
+* [The Advanced Guide to UserDefaults in Swift](https://www.vadimbulavin.com/advanced-guide-to-userdefaults-in-swift/), by [@justeat_tech](https://twitter.com/justeat_tech)
+* [Lessons learned from handling JWT on mobile](https://medium.com/just-eat-tech/lessons-learned-from-handling-jwt-on-mobile-c6e4b1d4fed6), by [@V8tr](https://twitter.com/V8tr)
 
 **Tools/Controls**
 
@@ -21,4 +22,4 @@
 
 **Credits**
 
-* [V8tr](https://github.com/V8tr)
+* [V8tr](https://github.com/V8tr), [albertodebortoli](https://github.com/albertodebortoli)


### PR DESCRIPTION
This Medium article is *not* behind the metered paywall. An alternative link is https://albertodebortoli.com/2019/12/04/recommendations-on-handling-jwt-on-mobile/.

## Checklist

* [x] The links are in the correct format: ``[Title of the Article](link), by [@author/`s Twitter username](link-for-twitter)``
* [x] I added my self to the credits with my GitHub account: ``[GitHub account](link-to-github)``

## Optional

* [x] Article is not more than 2 weeks old
* [x] Article wasn't submitted before 

