### PR TITLE
Add swift-mod tool

### DIFF
--- a/Issues/Week317.md
+++ b/Issues/Week317.md
@@ -10,6 +10,7 @@
 
 * [Spek](https://github.com/onmyway133/Spek), by [@onmyway133](https://twitter.com/onmyway133)
 * [Swift Embedded](https://github.com/swift-embedded/swift-embedded), by [Alan Dragomirecký](https://github.com/dragomirecky)
+* [swift-mod](https://github.com/ra1028/swift-mod), by [@ra1028fe5](https://twitter.com/ra1028fe5)
 
 **Business/Career**
 
@@ -24,4 +25,4 @@
 
 **Credits**
 
-* [onmyway133](https://github.com/onmyway133), [thomas-sivilay](https://github.com/thomas-sivilay), [V8tr](https://github.com/V8tr), [sarunw](https://github.com/sarunw)
+* [onmyway133](https://github.com/onmyway133), [thomas-sivilay](https://github.com/thomas-sivilay), [V8tr](https://github.com/V8tr), [sarunw](https://github.com/sarunw), [Ryo Aoyama](https://github.com/ra1028)


### PR DESCRIPTION
I added [swift-mod](https://github.com/ra1028/swift-mod) to the tool section in Week317.

## Checklist

* [x] The links are in the correct format: ``[Title of the Article](link), by [@author/`s Twitter username](link-for-twitter)``
* [x] I added my self to the credits with my GitHub account: ``[GitHub account](link-to-github)``
