### PR TITLE
Add Certificate Pinning in iOS Article

### DIFF
--- a/Issues/Week318.md
+++ b/Issues/Week318.md
@@ -1,6 +1,7 @@
 **Articles**
 
 * [Ranges in Swift explained with code examples](https://medium.com/flawless-app-stories/ranges-in-swift-explained-with-code-examples-ced68c750bd5), by [@twannl](https://twitter.com/twannl)
+* [Certificate Pinning in iOS](https://www.netguru.com/codestories/certificate-pinning-in-ios), by Karol Piątek
 
 
 **Tools/Controls**
@@ -22,3 +23,4 @@
 **Credits**
 
 * [LisaDziuba](https://github.com/lisadziuba)
+* [Karol Piątek](https://github.com/karolpiateknet)


### PR DESCRIPTION
## Checklist

* [x] The links are in the correct format: ``[Title of the Article](link), by [@author/`s Twitter username](link-for-twitter)``
* [x] I added my self to the credits with my GitHub account: ``[GitHub account](link-to-github)``

## Optional

* [x] Article is not more than 2 weeks old
* [x] Article wasn't submitted before 

