### PR TITLE
Fix moving article to Articles section instead of Tools/Controls

### DIFF
--- a/Issues/Week335.md
+++ b/Issues/Week335.md
@@ -1,11 +1,11 @@
 
 **Articles**
 
-*  
+* [Improving your App’s Accessibility with iOS 13](https://medium.com/@dadederk/improving-your-apps-accessibility-with-ios-13-9eb8fc0bc8a0), by [@dadederk](https://twitter.com/dadederk)  
 
 **Tools/Controls**
 
-* [Improving your App’s Accessibility with iOS 13](https://medium.com/@dadederk/improving-your-apps-accessibility-with-ios-13-9eb8fc0bc8a0), by [@dadederk](https://twitter.com/dadederk)
+* 
 
 **Business/Career**
 


### PR DESCRIPTION
I'm so sorry. I've added the article to the Tools/Controls section instead of Articles 🤦‍♂️ I hope it's ok. Thanks.

## Checklist

* [x] The links are in the correct format: ``[Title of the Article](link), by [@author/`s Twitter username](link-for-twitter)``
* [x] I added my self to the credits with my GitHub account: ``[GitHub account](link-to-github)``

## Optional

* [x] Article is not more than 2 weeks old
* [x] Article wasn't submitted before 

