### PR TITLE
Added "SwiftUI Search Bar in the Navigation Bar" to Articles

### DIFF
--- a/Issues/Week335.md
+++ b/Issues/Week335.md
@@ -8,6 +8,7 @@
 * [SwiftUI Previews at Scale](https://www.vadimbulavin.com/swiftui-previews-at-scale/), by [@V8tr](https://twitter.com/V8tr)
 * [Building a Design System for iOS](https://www.ramshandilya.com/blog/design-system-intro/), by [@ramshandilya](https://twitter.com/ramshandilya)
 * [Building server-driven-UI architecture using UIComponents in SwiftUI](https://medium.com/better-programming/build-a-server-driven-ui-using-ui-components-in-swiftui-466ecca97290), by [@AnupAmmanavar](https://twitter.com/AnupAmmanavar)
+* [SwiftUI Search Bar in the Navigation Bar](http://blog.eppz.eu/swiftui-search-bar-in-the-navigation-bar), by [@Geri_Borbas](https://twitter.com/Geri_Borbas)
 
 **Tools/Controls**
 
@@ -27,4 +28,4 @@
 
 **Credits**
 
-* [dadederk](https://github.com/dadederk), [LeeKahSeng](https://github.com/LeeKahSeng), [V8tr](https://github.com/V8tr), [ramshandilya](https://github.com/Ramshandilya), [thomassivilay](https://github.com/thomas-sivilay), [AnupAmmanavar](https://github.com/AnupAmmanavar)
+* [dadederk](https://github.com/dadederk), [LeeKahSeng](https://github.com/LeeKahSeng), [V8tr](https://github.com/V8tr), [ramshandilya](https://github.com/Ramshandilya), [thomassivilay](https://github.com/thomas-sivilay), [AnupAmmanavar](https://github.com/AnupAmmanavar), [Geri-Borbas](https://github.com/Geri-Borbas)


### PR DESCRIPTION
_"Instead of building a new SwiftUI search bar from the ground up, this article simply uses the **native UIKit search bar implementation** nicely equipped with all the necessary SwiftUI bindings."_

The article can provide some insights on how to implement some tricky UIKit interop to access more “native" features than the default stock SwiftUI.

## Checklist

* [x] The links are in the correct format: ``[Title of the Article](link), by [@author/`s Twitter username](link-for-twitter)``
* [x] I added my self to the credits with my GitHub account: ``[GitHub account](link-to-github)``

## Optional

* [x] Article is not more than 2 weeks old
* [x] Article wasn't submitted before 

