### PR TITLE
Added article

### DIFF
--- a/Issues/Week357.md
+++ b/Issues/Week357.md
@@ -5,6 +5,7 @@
 * [Composing SwiftUI views](https://fivestars.blog/swiftui/design-system-composing-views.html), by [@zntfdr](https://twitter.com/zntfdr)
 * [Playing Video with AVPlayer in SwiftUI](https://benoitpasquier.com/playing-video-avplayer-swiftui/), by [@benoitpasquier_](https://twitter.com/benoitpasquier_)
 * [The Ultimate Guide to the SwiftUI 2 Application Life Cycle](https://peterfriese.dev/ultimate-guide-to-swiftui2-application-lifecycle/), by [@peterfriese](https://twitter.com/peterfriese)
+* [Implementing In-App Purchases without Keychain and UserDefaults (Updated for Xcode 12)](https://medium.com/@rdovhaliuk/implementing-in-app-purchases-without-keychain-and-userdefaults-52a43c0f76e8), by [@rostyslav_d](https://twitter.com/rostyslav_d)
 
 **Tools/Controls**
 
@@ -24,4 +25,4 @@
 
 **Credits**
 
-* [mecid](https://github.com/mecid), [zntfdr](https://github.com/zntfdr), [peterfriese](https://github.com/peterfriese), [onmyway133](https://github.com/onmyway133), [popei69](https://github.com/popei69)
+* [mecid](https://github.com/mecid), [zntfdr](https://github.com/zntfdr), [peterfriese](https://github.com/peterfriese), [onmyway133](https://github.com/onmyway133), [popei69](https://github.com/popei69), [RenGate](https://github.com/rengate)


### PR DESCRIPTION
Hi folks. Recently I updated my 2019 article about In-App purchases that you featured in Week 269 to cover the new stuff introduced in Xcode 12. Hope, it is possible to feature revised articles. Thanks!

## Checklist

* [x] The links are in the correct format: ``[Title of the Article](link), by [@author/`s Twitter username](link-for-twitter)``
* [x] I added my self to the credits with my GitHub account: ``[GitHub account](link-to-github)``
* [x] The link is freely available for everyone to read without the need to pay or to create a free account
* [x] I placed the link at the bottom of its category.
* [x] I acknowledge that there's another curation step and that merging this pull request doesn't automatically guarantee the submitted article will be in the newsletter. See [the contributing guides](https://github.com/iOS-Goodies/iOS-Goodies/blob/master/CONTRIBUTING.md#contributing)

## Optional

* [ ] Article is not more than 2 weeks old
* [ ] Article wasn't submitted before 

