### PR TITLE
Add ColorKit to Tools/Controls

### DIFF
--- a/Issues/Week363.md
+++ b/Issues/Week363.md
@@ -10,6 +10,7 @@
 **Tools/Controls**
 
 * [Kanvas: Tumblr’s Media Editor and Camera](https://github.com/tumblr/kanvas-ios), by [@tumblreng](https://twitter.com/tumblreng)
+* [ColorKit](https://github.com/Boris-Em/ColorKit), by [@Boris-Em](https://twitter.com/boris_em?lang=en)
 
 **Business/Career**
 
@@ -25,4 +26,4 @@
 
 **Credits**
 
-* [zntfdr](https://github.com/zntfdr), [LeeKahSeng](https://github.com/LeeKahSeng), [pmusolino](https://github.com/pmusolino), [sarunw](https://github.com/sarunw), [fassko](https://github.com/fassko), [Joe Masilotti](https://github.com/joemasilotti)
+* [zntfdr](https://github.com/zntfdr), [LeeKahSeng](https://github.com/LeeKahSeng), [pmusolino](https://github.com/pmusolino), [sarunw](https://github.com/sarunw), [fassko](https://github.com/fassko), [Joe Masilotti](https://github.com/joemasilotti), [Boris-Em](https://github.com/Boris-Em)


### PR DESCRIPTION
I've just open sourced ColorKit and thought it might be interesting to iOS Goodies readers.

## Checklist

* [x] The links are in the correct format: ``[Title of the Article](link), by [@author/`s Twitter username](link-for-twitter)``
* [x] I added my self to the credits with my GitHub account: ``[GitHub account](link-to-github)``
* [x] The link is freely available for everyone to read without the need to pay or to create a free account
* [x] I placed the link at the bottom of its category.
* [x] I acknowledge that there's another curation step and that merging this pull request doesn't automatically guarantee the submitted article will be in the newsletter. See [the contributing guides](https://github.com/iOS-Goodies/iOS-Goodies/blob/master/CONTRIBUTING.md#contributing)

## Optional

* [x] Article is not more than 2 weeks old
* [x] Article wasn't submitted before 

