### PR TITLE
Add KeyWindow article and Github Repo

### DIFF
--- a/Issues/Week366.md
+++ b/Issues/Week366.md
@@ -29,4 +29,4 @@
 
 **Credits**
 
-* [mecid](https://github.com/mecid), [zntfdr](https://github.com/zntfdr), [onmyway133](https://github.com/onmyway133), [sarunw](https://github.com/sarunw), [michael_tigas](https://github.com/teeeeeegz), [dreymonde](https://github.com/dreymonde), [fassko](https://github.com/fassko)
+* [mecid](https://github.com/mecid), [zntfdr](https://github.com/zntfdr), [onmyway133](https://github.com/onmyway133), [sarunw](https://github.com/sarunw), [michael_tigas](https://github.com/teeeeeegz), [dreymonde](https://github.com/dreymonde), [fassko](https://github.com/fassko), [hishnash](https://github.com/hishnash)

--- a/Issues/Week366.md
+++ b/Issues/Week366.md
@@ -8,10 +8,12 @@
 * [How to use DateFormatter in Swift](https://sarunw.com/posts/how-to-use-dateformatter/), by [@sarunw](https://twitter.com/sarunw)
 * [Keep private information out of your logs with Swift](https://olegdreyman.medium.com/keep-private-information-out-of-your-logs-with-swift-bbd2fbcd9a40), by [@olegdreyman](https://twitter.com/olegdreyman)
 * [Background Color with SwiftUI](https://kristaps.me/blog/background-swiftui/), by [@fassko](https://twitter.com/fassko)
+* [KeyWindow a better way of exposing values from the Key window](https://lostmoa.com/blog/KeyWindowABetterWayOfExposingValuesFromTheKeyWindow/), by [@hishnash](https://twitter.com/hishnash)
 
 **Tools/Controls**
 
 * [awesome-swiftui](https://github.com/onmyway133/awesome-swiftui), by [@onmyway133](https://twitter.com/onmyway133)
+* [KeyWindow](https://github.com/LostMoa/KeyWindow), by [@hishnash](https://twitter.com/hishnash)
 
 **Business/Career**
 * [Launching an Indie App - Part 4: Architecting for Productivity](https://heyimakeapps.com/blog/launching-an-indie-app-part-4-architecting-for-productivity), by [@michael_tigas](https://twitter.com/michael_tigas)


### PR DESCRIPTION
This is a tool/article providing a new way of passing values to the commands section of a SwiftUI app even when the user is not focused on a text field.

## Checklist

* [x] The links are in the correct format: ``[Title of the Article](link), by [@author/`s Twitter username](link-for-twitter)``
* [x] I added my self to the credits with my GitHub account: ``[GitHub account](link-to-github)``
* [x] The link is freely available for everyone to read without the need to pay or to create a free account
* [x] I placed the link at the bottom of its category.
* [x] I acknowledge that there's another curation step and that merging this pull request doesn't automatically guarantee the submitted article will be in the newsletter. See [the contributing guides](https://github.com/iOS-Goodies/iOS-Goodies/blob/master/CONTRIBUTING.md#contributing)

## Optional

* [x] Article is not more than 2 weeks old
* [x] Article wasn't submitted before 

