### PR TITLE
Useful tip about includeIf in git config interfering with Xcode package management

### DIFF
--- a/Issues/Week401.md
+++ b/Issues/Week401.md
@@ -1,6 +1,6 @@
 **Tips from Twitter**
 
-*
+* ("includeIf" in the git config can prevent you from using packages in Xcode)[https://twitter.com/cristiankocza/status/1433778633626247172]: the "includeIf" directive, if present in your global ~/.gitconfig file, will lead to Xcode not being able to import or discover packages.
 
 **Articles**
 
@@ -25,3 +25,4 @@
 **Contributors**
 
 * [zntfdr](https://github.com/zntfdr)
+* [cristik](https://www.github.com/cristik)


### PR DESCRIPTION
## Checklist

* [x] The links are in the correct format: ``[Title of the Article](link), by [@author/`s Twitter username](link-for-twitter)``
* [x] I added my self to the credits with my GitHub account: ``[GitHub account](link-to-github)``
* [x] The link is freely available for everyone to read without the need to pay or to create a free account
* [x] I placed the link at the bottom of its category.
* [x] I acknowledge that there's another curation step and that merging this pull request doesn't automatically guarantee the submitted article will be in the newsletter. See [the contributing guides](https://github.com/iOS-Goodies/iOS-Goodies/blob/master/CONTRIBUTING.md#contributing)

## Optional

* [x] Article is not more than 2 weeks old
* [x] Article wasn't submitted before 

